### PR TITLE
Only write a body if it is specified in the response

### DIFF
--- a/web/__init__.py
+++ b/web/__init__.py
@@ -71,8 +71,9 @@ def _verbs_dict_to_tornado_handler_class(verbs_or_handler: (':or', {str: callabl
 
 @schema.check
 def _update_handler_from_dict_resp(resp: schemas.resp, handler: RequestHandler) -> None:
-    body = resp.get('body', '')
-    handler.write(body)
+    body = resp.get('body', None)
+    if body:
+        handler.write(body)
     handler.set_status(resp.get('code', 200), resp.get('reason', ''))
     for header, value in resp.get('headers', {}).items():
         handler.set_header(header, value)


### PR DESCRIPTION
It's illegal to write a body (even an empty one) for an HTTP 204